### PR TITLE
fix table sort

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -231,8 +231,8 @@
                         let newA = key.split('.').reduce((obj, i) => obj[i], a)
                         let newB = key.split('.').reduce((obj, i) => obj[i], b)
 
-                        if (!newA) return 1
-                        if (!newB) return 0
+                        if (!newA && newA !== 0) return 1
+                        if (!newB && newB !== 0) return 0
 
                         newA = (typeof newA === 'string')
                             ? newA.toUpperCase()


### PR DESCRIPTION
Sort all falsy values except 0 to end, leave 0 values in normal sort order. Fixes 0 values being sorted to end, e.g., a list of numbers sorted as [1, 2, 0], where one would expect [0, 1, 2]. Null values still sorted to end, e.g., [0, 1, 2, null].