### PR TITLE
Fix bug in dropdown 

### DIFF
--- a/src/scss/components/_dropdown.scss
+++ b/src/scss/components/_dropdown.scss
@@ -13,6 +13,7 @@
         background-color: rgba($black, 0.86);
         z-index: 10;
         transition: opacity $speed $easing;
+        cursor: pointer;
     }
     .box {
         position: absolute;


### PR DESCRIPTION
Fixing a bug in the dropdown component. This only happens on mobiles with IOS. You try to close the dropdown when clicking outside it and nothing happens. To correct it simply add a `cursor: pointer` in the style of `.dropdown.brackground`