### PR TITLE
:bug: Adding flex-direction to tab-content

### DIFF
--- a/src/scss/components/_tabs.scss
+++ b/src/scss/components/_tabs.scss
@@ -3,6 +3,7 @@
         position: relative;
         overflow: hidden;
         display: flex;
+        flex-direction: column;
         .tab-item {
             flex-shrink: 0;
             flex-basis: 100%;


### PR DESCRIPTION
This prevents long elements such as pre and code blocks that have a long string of text in them from overflowing off the container of the tab-content

## Example

See example _code block was set to width 100%_

<img width="1352" alt="screenshot 2017-06-04 15 53 08" src="https://cloud.githubusercontent.com/assets/8116716/26764885/0fded63e-493e-11e7-8916-e52b09c745ce.png">

This should be restricted to the container width. To fix this I added the flex-direction column rule to the `.tabs-content` class.

## Fix

This makes the code block the proper width and is constrained to the size of the tab-content container rather than overflowing

<img width="1044" alt="screenshot 2017-06-04 15 53 37" src="https://cloud.githubusercontent.com/assets/8116716/26764890/35786eaa-493e-11e7-9bfc-3978f7c138c7.png">

