### PR TITLE
update quick start codes in README with semicolons for easy copy-pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ npm install buefy
 ### Import and use Buefy. You can also enable individual components
 
 ```javascript
-import Vue from 'vue'
-import Buefy from 'buefy'
-import 'buefy/lib/buefy.css'
+import Vue from 'vue';
+import Buefy from 'buefy';
+import 'buefy/lib/buefy.css';
 
-Vue.use(Buefy)
+Vue.use(Buefy);
 
 // OR
 
-Vue.component(Buefy.Checkbox.name, Buefy.Checkbox)
-Vue.component(Buefy.Table.name, Buefy.Table)
+Vue.component(Buefy.Checkbox.name, Buefy.Checkbox);
+Vue.component(Buefy.Table.name, Buefy.Table);
 ...
 ```
 


### PR DESCRIPTION
Added semicolons to make it easy to copy-paste. Prevents making careless mistakes while copy-pasting over to projects. Makes things easier for people to pick up and implement buefy from the get-go.