### PR TITLE
Correct example property names for prompt.

### DIFF
--- a/docs/pages/documentation/notices/Dialog.vue
+++ b/docs/pages/documentation/notices/Dialog.vue
@@ -230,8 +230,8 @@
                         prompt() {
                             this.$dialog.prompt({
                                 message: \`What's your name?\`,
-                                maxlength: 20,
-                                placeholder: 'e.g. John Doe',
+                                inputMaxlength: 20,
+                                inputPlaceholder: 'e.g. John Doe',
                                 onConfirm: (value) => {
                                     this.$toast.open('Your name is: ' + value)
                                 }


### PR DESCRIPTION
Found a couple of typos in the documentation for the dialog prompt. 

Keep up the good work.