### PR TITLE
Enter key press on Autocomplete option into a Form

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -21,8 +21,8 @@
             autocomplete="off"
             @focus="focused"
             @blur="blur"
-            @keyup.native.enter.prevent="enterPressed"
             @keyup.native.esc.prevent="isActive = false"
+            @keydown.native.enter.prevent="enterPressed"
             @keydown.native.up.prevent="keyArrows('up')"
             @keydown.native.down.prevent="keyArrows('down')">
         </b-input>


### PR DESCRIPTION
Hi Rafael,
i have just fixed a issue about enter key press on autocomplete option into a Form.
In the last release 0.4.4, enter key press on option not work because the option (hover) isn't selected and the form is submitted.
I have changed from keyup to keydown and i have just tried this fix in all browsers (IE10+, Chrome, Firefox, Safari).