### PR TITLE
"Lazy" binding Input component

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -21,8 +21,8 @@
             autocomplete="off"
             @focus="focused"
             @blur="blur"
-            @keyup.native.enter.prevent="enterPressed"
             @keyup.native.esc.prevent="isActive = false"
+            @keydown.native.enter.prevent="enterPressed"
             @keydown.native.up.prevent="keyArrows('up')"
             @keydown.native.down.prevent="keyArrows('down')">
         </b-input>

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -174,7 +174,6 @@
                 const value = event.target.value
                 this.newValue = value
                 this.$emit('input', value)
-                this.$emit('change', value)
                 !this.isValid && this.checkHtml5Validity()
             },
 


### PR DESCRIPTION
Hi Rafael,
i have just fixed a issue about Input component. 
At the moment it's imposibile have a "lazy" binding; according to Vue documentation v-model.lazy is equals to :value and @change: but now the input method related to Input component emit a 'change' event and so it's impossibile have only the final value (on change).