### PR TITLE
Fix Autocomplete docs (Async example) and double emit 'input' event

### DIFF
--- a/docs/pages/documentation/form/Autocomplete.vue
+++ b/docs/pages/documentation/form/Autocomplete.vue
@@ -56,7 +56,7 @@
                     field="title"
                     has-custom-template
                     :loading="asyncExample.isFetching"
-                    @change="getAsyncData"
+                    @input="getAsyncData"
                     @select="option => asyncExample.selected = option">
 
                     <template scope="props">
@@ -489,7 +489,7 @@
                         field="title"
                         has-custom-template
                         :loading="asyncExample.isFetching"
-                        @change="getAsyncData"
+                        @input="getAsyncData"
                         @select="option => asyncExample.selected = option">
 
                         <template scope="props">

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -189,7 +189,6 @@
                 this.$emit('select', this.selected)
                 if (this.selected !== null) {
                     this.newValue = this.getValue(this.selected)
-                    this.$emit('input', this.getValue(this.selected))
                 }
                 closeDropdown && this.$nextTick(() => { this.isActive = false })
             },


### PR DESCRIPTION
@rafaelpimpa 
I have just fixed the docs (now @input => real time) and a issue about double emit 'input' event on select. As you can see the watch function on newValue emit a 'input' so it's not required to emit an other event after the assignment. 