### PR TITLE
B-Table: InitSort async data

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -162,7 +162,8 @@
                 isAsc: true,
                 mobileSort: {},
                 currentPage: 1,
-                _isTable: true // Used by TableColumn
+                _isTable: true, // Used by TableColumn
+                _firstTimeSort: true // Used by first time initSort
             }
         },
         watch: {
@@ -199,6 +200,16 @@
              */
             checkedRows(rows) {
                 this.newCheckedRows = [...rows]
+            },
+
+            /**
+             * When columns change, call initSort only first time (For example async data).
+             */
+            columns(columns) {
+                if (this.$data._firstTimeSort) {
+                    this.initSort()
+                    this.$data._firstTimeSort = false
+                }
             }
         },
         computed: {
@@ -391,9 +402,6 @@
                     }
                 })
             }
-        },
-        mounted() {
-            this.initSort()
         }
     }
 </script>

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -162,8 +162,8 @@
                 isAsc: true,
                 mobileSort: {},
                 currentPage: 1,
-                _isTable: true, // Used by TableColumn
-                _firstTimeSort: true // Used by first time initSort
+                firstTimeSort: true, // Used by first time initSort
+                _isTable: true // Used by TableColumn
             }
         },
         watch: {
@@ -206,9 +206,9 @@
              * When columns change, call initSort only first time (For example async data).
              */
             columns(columns) {
-                if (this.$data._firstTimeSort) {
+                if (this.firstTimeSort) {
                     this.initSort()
-                    this.$data._firstTimeSort = false
+                    this.firstTimeSort = false
                 }
             }
         },


### PR DESCRIPTION
#164 
The main problem is about async data in other words when the b-table is ready but data aren't loaded (ajax or other). 
Backend sorting it's ok (server sort) but I can't see what is the default sort column (arrow down or up) because when initSort is called the columns aren't ready (empty array). Same issue no backend sort but always async data.
I don't know if it's the best solution but in the current logic the columns array is required to find the default column and sorting.