### PR TITLE
Fix default value for b-table data prop

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -144,7 +144,7 @@
         props: {
             data: {
                 type: Array,
-                default: []
+                default: () => []
             },
             bordered: Boolean,
             striped: Boolean,


### PR DESCRIPTION
To avoid the Vue warning : `[Vue warn]: Invalid default value for prop "data": Props with type Object/Array must use a factory function to return the default value.`