### PR TITLE
Fix spelling error in Tooltip documentation

### DIFF
--- a/docs/pages/documentation/general/Tooltip.vue
+++ b/docs/pages/documentation/general/Tooltip.vue
@@ -244,7 +244,7 @@
                 </b-tooltip>
 
                 <b-tooltip
-                    label="Tooltip large multilined, because it's really long to be on a medium size. Did I tell you it's really long? Yes, it is — I asure you!"
+                    label="Tooltip large multilined, because it's really long to be on a medium size. Did I tell you it's really long? Yes, it is — I assure you!"
                     position="is-bottom"
                     multilined
                     size="is-large">


### PR DESCRIPTION
Fixes a spelling error in the Tooltip documentation, specifically on the large multilined tooltip example.

Expected output:

![screen shot 2017-08-03 at 10 33 09 pm](https://user-images.githubusercontent.com/13021310/28951910-c8ab1c5e-789b-11e7-9bcf-446a634c17b4.png)
