### PR TITLE
Moved sort $emit up, allowing custom sort to be used

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -352,11 +352,11 @@
                         ? !this.isAsc
                         : this.isAsc = true
                 }
+                this.$emit('sort', column.field, this.isAsc ? 'asc' : 'desc')
                 if (!this.backendSorting) {
                     this.newData = this.sortBy(this.newData, column.field, column.customSort, this.isAsc)
                 }
                 this.currentSortColumn = column
-                this.$emit('sort', column.field, this.isAsc ? 'asc' : 'desc')
             },
 
             /**


### PR DESCRIPTION
There is currently a shortcoming of the customSort behavior : we don't have access to the sort order which is crucial if we want to implement a proper sort.
The only way to get the current sort order is by listening to the sort event, but this event is not emitted before the actual sort takes place.
This pull request simply move the $emit call before the actual sort happens, effectively solving the problem.
BUT : 
We may need some refactoring because some people may expect the event to be emitted after the actual sort ...
