### PR TITLE
Fix sort and pagination errors on detailed table by removing the :key…

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -86,7 +86,6 @@
                         </tr>
 
                         <tr v-if="detailed && isVisibleDetailRow(row)"
-                            :key="index"
                             class="detail">
                             <td :colspan="columnCount">
                                 <div class="detail-container">


### PR DESCRIPTION
… prop on tr.

There is currently a conflict when the table use the `detailed` props for displaying a collapsible row under each row. The same keys are used on two different elements the real `tr` and the detailed one. 

The fix I PR'ed is to remove the `:key` prop, but in fact another potential fix that you might prefer is to use `:key="index + visibleData.length"`to make sure that there are no conflicting keys.