### PR TITLE
Support for Font Awesome 5

### DIFF
--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -1,6 +1,6 @@
 <template>
     <span class="icon" :class="[type, size]">
-        <i :class="[newPack, isFontAwesome ? `${newPack}-${newIcon}` : null ]">{{ newPack === 'mdi' ? newIcon : null }}</i>
+        <i :class="[newPack, isFontAwesome ? `fa-${newIcon}` : null ]">{{ newPack === 'mdi' ? newIcon : null }}</i>
     </span>
 </template>
 

--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -38,7 +38,7 @@
              * Naive Font Awesome configuration check
              */
             isFontAwesome() {
-                return this.newPack.slice(0, 2) === 'fa';
+                return this.newPack.slice(0, 2) === 'fa'
             }
         },
         methods: {

--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -1,6 +1,6 @@
 <template>
     <span class="icon" :class="[type, size]">
-        <i :class="[newPack, newPack === 'fa' ? `fa-${newIcon}` : null ]">{{ newPack === 'mdi' ? newIcon : null }}</i>
+        <i :class="[newPack, isFontAwesome ? `${newPack}-${newIcon}` : null ]">{{ newPack === 'mdi' ? newIcon : null }}</i>
     </span>
 </template>
 
@@ -33,6 +33,12 @@
                 } else {
                     return this.icon
                 }
+            },
+            /**
+             * Naive Font Awesome configuration check
+             */
+            isFontAwesome() {
+                return this.newPack.slice(0, 2) === 'fa';
             }
         },
         methods: {


### PR DESCRIPTION
font awesome 5 will require varying prefixes for solid, normal and light options (e.g. `fa` vs `fal` `fas` etc.). this change would enable utilization by simply specifying via the existing `defaultIconPack` configuration for buefy.