### PR TITLE
#283 Full width and text-align to left for .detail-container

### DIFF
--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -90,6 +90,8 @@
             background: $white-bis;
             .detail-container {
                 padding: 1rem;
+                width: 100%;
+                text-align: left;
             }
         }
         // Modifiers


### PR DESCRIPTION
Fix #283
In .has-mobile-cards mobile tr td:before, is padding-right: 0.5em really useful ? It takes up place for nothing in detail rows.