### PR TITLE
Fix checkbox shrinking when text is very long

### DIFF
--- a/src/scss/components/_checkbox.scss
+++ b/src/scss/components/_checkbox.scss
@@ -15,6 +15,7 @@ $checkbox-checkmark-color: $primary-invert !default;
             + .check {
                 width: 1.25em;
                 height: 1.25em;
+                flex-shrink: 0;
                 border-radius: $radius;
                 border: 2px solid $grey;
                 transition: background $speed-slow $easing;


### PR DESCRIPTION
When you use `b-checkbox` with long labels in restricted width context, the checkbox shrinks.


Repro with the fix commented :
https://jsfiddle.net/Tirke/sz8Lpk6y/1/