### PR TITLE
Handle tab in autoselect

### DIFF
--- a/docs/pages/documentation/form/autocomplete/api.js
+++ b/docs/pages/documentation/form/autocomplete/api.js
@@ -3,7 +3,7 @@ export default [
         props: [
             {
                 name: '<code>v-model</code>',
-                description: 'Bindig value',
+                description: 'Binding value',
                 type: 'String, Number',
                 values: '—',
                 default: '—'
@@ -31,7 +31,7 @@ export default [
             },
             {
                 name: '<code>keep-first</code>',
-                description: 'The first option will always be pre-selected (easier to just hit enter)',
+                description: 'The first option will always be pre-selected (easier to just hit enter or tab)',
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -12,6 +12,7 @@
             @focus="focused"
             @blur="$emit('blur', $event)"
             @keyup.native.esc.prevent="isActive = false"
+            @keydown.native.tab="tabPressed"
             @keydown.native.enter.prevent="enterPressed"
             @keydown.native.up.prevent="keyArrows('up')"
             @keydown.native.down.prevent="keyArrows('down')">
@@ -209,6 +210,19 @@
              */
             enterPressed() {
                 if (this.hovered === null) return
+                this.setSelected(this.hovered)
+            },
+
+            /**
+             * Tab key listener.
+             * Select hovered option if it exists, close dropdown, then allow
+             * native handling to move to next tabbable element.
+             */
+            tabPressed() {
+                if (this.hovered === null) {
+                    this.isActive = false
+                    return
+                }
                 this.setSelected(this.hovered)
             },
 


### PR DESCRIPTION
Previously, pressing `tab` on an autocomplete field would move to the next tabbable element on the page but leave the dropdown open.  This PR closes the dropdown while permitting native `tab` handling to move to the next element.

Additionally, if there is a hovered option it will select it (the same as pressing `enter`) and move to the next element.  This provides for even faster data entry especially when used in conjunction with the `keep-first` option.