### PR TITLE
add src/scss/utils/_all.scss

### DIFF
--- a/src/scss/buefy.scss
+++ b/src/scss/buefy.scss
@@ -1,7 +1,4 @@
-@import "utils/_functions";
-@import "utils/_variables";
-@import "utils/_helpers";
-@import "utils/_animations";
+@import "utils/_all";
 
 @import "components/_autocomplete";
 @import "components/_checkbox";

--- a/src/scss/utils/_all.scss
+++ b/src/scss/utils/_all.scss
@@ -1,0 +1,4 @@
+@import "_functions.scss";
+@import "_variables.scss";
+@import "_helpers.scss";
+@import "_animations.scss";


### PR DESCRIPTION
Add src/scss/utils/_all.scss to make modular css importing easier. Change import of utils in src/scss/buefy.scss to reflect the addition.

Also, add to documentation at https://buefy.github.io/#/documentation/customization, maybe as alternate code for example under "It can be done in your App.vue within the <style lang="scss"> tag"?:

```
// import Bulma + Buefy base and utilities
@import "~bulma/sass/base/_all";
@import "~bulma/sass/utilities/_all";
@import "~buefy/src/scss/utils/_all";

// set colors
$primary: #8c67ef;
$primary-invert: findColorInvert($primary);

// import only the Bulma styling you want
@import "~bulma/sass/grid/columns";
@import "~bulma/sass/elements/title";

// import only the Buefy components you want
@import "~buefy/src/scss/components/_checkbox";
@import "~buefy/src/scss/components/_radio";
```

If you're only using a few Buefy components, this can save 100K+ in your production build.