### PR TITLE
Fix #395 check $refs.dropdown availability before use

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -259,6 +259,12 @@
              */
             calcDropdownInViewportVertical() {
                 this.$nextTick(() => {
+                    /**
+                     * this.$refs.dropdown may be undefined
+                     * when Autocomplete is conditional rendered
+                     */
+                    if (this.$refs.dropdown === undefined) return
+
                     const rect = this.$refs.dropdown.getBoundingClientRect()
 
                     this.isListInViewportVertically = (


### PR DESCRIPTION
This fixes #395, adds type check for dropdown in `calcDropdownInViewportVertical()`.