### PR TITLE
Ensure expanded prop works on tabs

### DIFF
--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="b-tabs">
+    <div class="b-tabs" :class="{ 'is-fullwidth': expanded }">
         <nav class="tabs" :class="[type, size, position, { 'is-fullwidth': expanded }]">
             <ul>
                 <li v-for="(tabItem, index) in tabItems"

--- a/src/scss/components/_tabs.scss
+++ b/src/scss/components/_tabs.scss
@@ -20,4 +20,7 @@
     &:not(:last-child) {
         margin-bottom: 1.5rem;
     }
+    &.is-fullwidth {
+        width: 100%;
+    }
 }


### PR DESCRIPTION
Depending on where the tabs component is nested, the `expanded` prop may not work. This simple change takes one more step to try & ensure that. When trying to implement tabs into a panel (example: https://bulma.io/documentation/components/panel) I ran across this issue. I apologize for this being split up into two commits.