### PR TITLE
Fixes the table details issues #423

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -92,7 +92,6 @@
                         </tr>
 
                         <tr v-if="detailed && isVisibleDetailRow(row)"
-                            :key="index"
                             class="detail">
                             <td :colspan="columnCount">
                                 <div class="detail-container">


### PR DESCRIPTION
We don't need the :key on the detailed row because cause conflicts with the main <tr> loop. 