### PR TITLE
Adds event indicators functionality to datepicker

### DIFF
--- a/docs/apis/apiDatepicker.js
+++ b/docs/apis/apiDatepicker.js
@@ -37,6 +37,20 @@ export default [
                 default: '—'
             },
             {
+                name: '<code>events</code>',
+                description: 'Dates to display indicators',
+                type: 'Array',
+                values: '—',
+                default: '—'
+            },
+            {
+                name: '<code>indicators</code>',
+                description: 'Shape to use when showing event indicators',
+                type: 'String',
+                values: '<code>dots</code>, <code>bars</code>',
+                default: '<code>dots</code>'
+            },
+            {
                 name: '<code>focused-date</code>',
                 description: 'Date that should be initially focused upon',
                 type: 'Date',

--- a/docs/examples/datepicker/ExEvents.vue
+++ b/docs/examples/datepicker/ExEvents.vue
@@ -1,0 +1,69 @@
+<template>
+    <span>
+        <b-field>
+            <b-switch v-model="bars">Bars</b-switch>
+        </b-field>
+        <b-datepicker
+            inline
+            v-model="date" 
+            :events="events"
+            :indicators="indicators"
+            >
+        </b-datepicker>
+    </span>
+</template>
+
+<script>
+    export default {
+        computed: {
+            indicators() {
+                return this.bars ? 'bars' : 'dots'
+            }
+        },
+        data() {
+            return {
+                date: new Date(2017, 10, 1),
+                events: [
+                    '11/02/2017',
+                    new Date(2017, 10, 4),
+                    '11/06/2017',
+                    {
+                        date: new Date(2017, 10, 8),
+                        type: 'is-danger'
+                    },
+                    {
+                        date: new Date(2017, 10, 10),
+                        type: 'is-success'
+                    },
+                    {
+                        date: new Date(2017, 10, 10),
+                        type: 'is-link'
+                    },
+                    new Date(2017, 10, 12),
+                    {
+                        date: new Date(2017, 10, 12),
+                        type: 'is-warning'
+                    },
+                    {
+                        date: new Date(2017, 10, 16),
+                        type: 'is-danger'
+                    },
+                    new Date(2017, 10, 20),
+                    {
+                        date: new Date(2017, 10, 29),
+                        type: 'is-success'
+                    },
+                    {
+                        date: new Date(2017, 10, 29),
+                        type: 'is-warning'
+                    },
+                    {
+                        date: new Date(2017, 10, 29),
+                        type: 'is-info'
+                    }
+                ],
+                bars: false
+            }
+        }
+    }
+</script>

--- a/docs/examples/datepicker/ExEvents.vue
+++ b/docs/examples/datepicker/ExEvents.vue
@@ -24,9 +24,9 @@
             return {
                 date: new Date(2017, 10, 1),
                 events: [
-                    '11/02/2017',
+                    new Date(2017, 10, 2),
                     new Date(2017, 10, 4),
-                    '11/06/2017',
+                    new Date(2017, 10, 6),
                     {
                         date: new Date(2017, 10, 8),
                         type: 'is-danger'

--- a/docs/examples/datepicker/ExEvents.vue
+++ b/docs/examples/datepicker/ExEvents.vue
@@ -14,6 +14,8 @@
 </template>
 
 <script>
+    const thisMonth = new Date().getMonth()
+
     export default {
         computed: {
             indicators() {
@@ -22,43 +24,46 @@
         },
         data() {
             return {
-                date: new Date(2017, 10, 1),
+                date: new Date(2017, thisMonth, 1),
                 events: [
-                    new Date(2017, 10, 2),
-                    new Date(2017, 10, 4),
-                    new Date(2017, 10, 6),
+                    new Date(2017, thisMonth, 2),
+                    new Date(2017, thisMonth, 6),
                     {
-                        date: new Date(2017, 10, 8),
+                        date: new Date(2017, thisMonth, 6),
+                        type: 'is-info'
+                    },
+                    {
+                        date: new Date(2017, thisMonth, 8),
                         type: 'is-danger'
                     },
                     {
-                        date: new Date(2017, 10, 10),
+                        date: new Date(2017, thisMonth, 10),
                         type: 'is-success'
                     },
                     {
-                        date: new Date(2017, 10, 10),
+                        date: new Date(2017, thisMonth, 10),
                         type: 'is-link'
                     },
-                    new Date(2017, 10, 12),
+                    new Date(2017, thisMonth, 12),
                     {
-                        date: new Date(2017, 10, 12),
+                        date: new Date(2017, thisMonth, 12),
                         type: 'is-warning'
                     },
                     {
-                        date: new Date(2017, 10, 16),
+                        date: new Date(2017, thisMonth, 16),
                         type: 'is-danger'
                     },
-                    new Date(2017, 10, 20),
+                    new Date(2017, thisMonth, 20),
                     {
-                        date: new Date(2017, 10, 29),
+                        date: new Date(2017, thisMonth, 29),
                         type: 'is-success'
                     },
                     {
-                        date: new Date(2017, 10, 29),
+                        date: new Date(2017, thisMonth, 29),
                         type: 'is-warning'
                     },
                     {
-                        date: new Date(2017, 10, 29),
+                        date: new Date(2017, thisMonth, 29),
                         type: 'is-info'
                     }
                 ],

--- a/docs/pages/documentation/Datepicker.vue
+++ b/docs/pages/documentation/Datepicker.vue
@@ -69,6 +69,20 @@
         </div>
 
         <hr>
+
+        <h2 class="title">Events</h2>
+        <p class="content">Dates can be passed to the datepicker with the <code>events</code> prop and shown with indicators.</p>
+        <div class="columns">
+            <div class="column">
+                <ex-events></ex-events>
+            </div>
+            <div class="column">
+                <CodeView :code="ExEventsCode" />
+            </div>
+        </div>
+
+        <hr>
+
         <h2 class="title">API</h2>
         <ApiView :data="api" />
     </div>
@@ -92,13 +106,17 @@
     import ExInline from '@/examples/datepicker/ExInline'
     import ExInlineCode from '!!raw-loader!@/examples/datepicker/ExInline'
 
+    import ExEvents from '@/examples/datepicker/ExEvents'
+    import ExEventsCode from '!!raw-loader!@/examples/datepicker/ExEvents'
+
     export default {
         components: {
             ExSimple,
             ExNonReadonly,
             ExRange,
             ExFooter,
-            ExInline
+            ExInline,
+            ExEvents
         },
         data() {
             return {
@@ -107,7 +125,8 @@
                 ExNonReadonlyCode,
                 ExRangeCode,
                 ExFooterCode,
-                ExInlineCode
+                ExInlineCode,
+                ExEventsCode
             }
         }
     }

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -88,6 +88,8 @@
                     :focused="focusedDateData"
                     :disabled="disabled"
                     :unselectable-dates="unselectableDates"
+                    :events="events"
+                    :indicators="indicators"
                     @close="$refs.dropdown.isActive = false">
                 </b-datepicker-table>
 
@@ -238,7 +240,12 @@
                     return config.defaultDatepickerMobileNative
                 }
             },
-            position: String
+            position: String,
+            events: Array,
+            indicators: {
+                type: String,
+                default: 'dots'
+            }
         },
         data() {
             const focusedDate = this.value || this.focusedDate || new Date()

--- a/src/components/datepicker/DatepickerTable.vue
+++ b/src/components/datepicker/DatepickerTable.vue
@@ -80,7 +80,7 @@
                     if (!event.hasOwnProperty('type')) {
                         event.type = 'is-primary'
                     }
-                    if (event.date.getMonth() === this.focused.month && event.date.getUTCFullYear() === this.focused.year) {
+                    if (event.date.getMonth() === this.focused.month && event.date.getFullYear() === this.focused.year) {
                         monthEvents.push(event)
                     }
                 }

--- a/src/components/datepicker/DatepickerTable.vue
+++ b/src/components/datepicker/DatepickerTable.vue
@@ -7,7 +7,7 @@
                 {{ day }}
             </div>
         </header>
-        <div class="datepicker-body">
+        <div class="datepicker-body" :class="{'has-events':hasEvents}">
             <b-datepicker-table-row
                 v-for="(week, index) in weeksInThisMonth(focused.month, focused.year)"
                 :key="index"
@@ -18,6 +18,8 @@
                 :max-date="maxDate"
                 :disabled="disabled"
                 :unselectable-dates="unselectableDates"
+                :events="eventsInThisWeek(week, index)"
+                :indicators="indicators"
                 @select="updateSelectedDate">
             </b-datepicker-table-row>
         </div>
@@ -37,6 +39,8 @@
             dayNames: Array,
             monthNames: Array,
             firstDayOfWeek: Number,
+            events: Array,
+            indicators: String,
             minDate: Date,
             maxDate: Date,
             focused: Object,
@@ -53,6 +57,38 @@
                     index++
                 }
                 return visibleDayNames
+            },
+
+            hasEvents() {
+                return this.events && this.events.length
+            },
+
+            /*
+            * Return array of all events in the specified month
+            */
+            eventsInThisMonth() {
+                if (!this.events) return []
+
+                const monthEvents = []
+
+                for (let i = 0; i < this.events.length; i++) {
+                    let event = this.events[i]
+
+                    if (!event.hasOwnProperty('date')) {
+                        event = { date: event }
+                    }
+                    if (!event.hasOwnProperty('type')) {
+                        event.type = 'is-primary'
+                    }
+                    if (Object.prototype.toString.call(event.date) !== '[object Date]') {
+                        event.date = new Date(event.date)
+                    }
+                    if (event.date.getMonth() === this.focused.month && event.date.getUTCFullYear() === this.focused.year) {
+                        monthEvents.push(event)
+                    }
+                }
+
+                return monthEvents
             }
         },
         methods: {
@@ -121,6 +157,25 @@
                 }
 
                 return weeksInThisMonth
+            },
+
+            eventsInThisWeek(week, index) {
+                if (!this.eventsInThisMonth.length) return []
+
+                const weekEvents = []
+
+                let weeksInThisMonth = []
+                weeksInThisMonth = this.weeksInThisMonth(this.focused.month, this.focused.year)
+
+                for (let d = 0; d < weeksInThisMonth[index].length; d++) {
+                    for (let e = 0; e < this.eventsInThisMonth.length; e++) {
+                        if (this.eventsInThisMonth[e].date.getTime() === weeksInThisMonth[index][d].getTime()) {
+                            weekEvents.push(this.eventsInThisMonth[e])
+                        }
+                    }
+                }
+
+                return weekEvents
             }
         }
     }

--- a/src/components/datepicker/DatepickerTable.vue
+++ b/src/components/datepicker/DatepickerTable.vue
@@ -80,9 +80,6 @@
                     if (!event.hasOwnProperty('type')) {
                         event.type = 'is-primary'
                     }
-                    if (Object.prototype.toString.call(event.date) !== '[object Date]') {
-                        event.date = new Date(event.date)
-                    }
                     if (event.date.getMonth() === this.focused.month && event.date.getUTCFullYear() === this.focused.year) {
                         monthEvents.push(event)
                     }

--- a/src/components/datepicker/DatepickerTableRow.vue
+++ b/src/components/datepicker/DatepickerTableRow.vue
@@ -3,7 +3,7 @@
         <template v-for="(day, index) in week">
             <a v-if="selectableDate(day) && !disabled"
                 :key="index"
-                :class="classObject(day)"
+                :class="[classObject(day), {'has-event':eventsDateMatch(day)}, indicators]"
                 class="datepicker-cell"
                 role="button"
                 href="#"
@@ -12,6 +12,11 @@
                 @keydown.enter.prevent="emitChosenDate(day)"
                 @keydown.space.prevent="emitChosenDate(day)">
                 {{ day.getDate() }}
+
+                <div class="events" v-if="eventsDateMatch(day)">
+                    <div class="event" :class="event.type" v-for="(event, index) in eventsDateMatch(day)" :key="index"></div>
+                </div>
+                
             </a>
             <div v-else
                 :key="index"
@@ -39,7 +44,9 @@
             minDate: Date,
             maxDate: Date,
             disabled: Boolean,
-            unselectableDates: Array
+            unselectableDates: Array,
+            events: Array,
+            indicators: String
         },
         methods: {
             /*
@@ -80,6 +87,24 @@
                 if (this.selectableDate(day)) {
                     this.$emit('select', day)
                 }
+            },
+
+            eventsDateMatch(day) {
+                if (!this.events.length) return false
+
+                const dayEvents = []
+
+                for (let i = 0; i < this.events.length; i++) {
+                    if (this.events[i].date.getDay() === day.getDay()) {
+                        dayEvents.push(this.events[i])
+                    }
+                }
+
+                if (!dayEvents.length) {
+                    return false
+                }
+
+                return dayEvents
             },
 
             /*

--- a/src/scss/components/_datepicker.scss
+++ b/src/scss/components/_datepicker.scss
@@ -61,6 +61,51 @@
                     }
                 }
             }
+            &.has-events {
+                .datepicker-cell {
+                    padding: 0.3rem 0.75rem 0.75rem;
+                    &.has-event {
+                        position: relative;
+                        .events {
+                            bottom: .425rem;
+                            display: flex;
+                            justify-content: center;
+                            left: 0;
+                            padding: 0 .35rem;
+                            position: absolute;
+                            width: 100%;
+                            .event {
+                                @each $name, $pair in $colors {
+                                    $color: nth($pair, 1);
+                                    &.is-#{$name} {
+                                        background-color: $color;
+                                    }
+                                }
+                            }
+                        }
+                        &.dots .event {
+                            border-radius: 50%;
+                            height: .35em;
+                            margin: 0 .1em;
+                            width: .35em;
+                        }
+                        &.bars .event {
+                            height: .25em;
+                            width: 100%;
+                        }
+                    }
+                    &.is-selected {
+                        overflow: hidden;
+                        .events .event {
+                            // Currently datepicker only uses primary coloring
+                            // Ensure indicator is visible when selected
+                            &.is-primary {
+                                background-color: lighten($primary,15);
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
     &.is-small {


### PR DESCRIPTION
Using the datepicker inline can make for a great _simple_ event calendar, except there needed to be a way to see plotted events. This allows you to pass an array of dates to an `events` prop to see indicators. I did my best to ensure that adding the indicators didn't screw up the calendar date styles/sizes.

Dates in the array can be in specified a few different ways (string to be parsed, `new Date()`, or object with `date` & `type` keys for setting color on indicators).

I did _just_ notice that Buefy is already using the `events` prop elsewhere so that naming might be confusing. Open to changing this however you see fit.

Potential areas of concern are: data structuring, prop naming, _flexibility_ of date prop data (strings || objects).

Hopefully this is simple enough to be appended onto the datepicker, rather than breaking out a full-blown event calendar into it's own component. Let me know what changes need to be made. Thanks!

![image](https://user-images.githubusercontent.com/1377169/33140150-c36fe258-cf74-11e7-98aa-0ed0740e3eed.png)
![image](https://user-images.githubusercontent.com/1377169/33140157-c7d93948-cf74-11e7-8d97-4af206e4a487.png)

