### PR TITLE
Fix for "vue build" not working with vue-cli 2.9.0 onwards.

### DIFF
--- a/docs/apis/apiDropdown.js
+++ b/docs/apis/apiDropdown.js
@@ -38,6 +38,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>transition</code>',
+                description: 'Transition for dropdown menu.',
+                type: 'String',
+                values: '—',
+                default: '<code>fade</code>'
+            },
+            {
                 name: '<code>mobile-modal</code>',
                 description: 'Dropdown content (items) are shown into a modal on mobile',
                 type: 'Boolean',

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "sw-precache-webpack-plugin": "^0.9.1",
     "url-loader": "^0.5.8",
     "vue-analytics": "^4.1.3",
+    "vue-cli": "2.8.0",
     "vue-loader": "^12.1.0",
     "vue-progressbar": "^0.7.2",
     "vue-router": "^2.3.1",

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -6,7 +6,7 @@
             'is-inline': inline,
             'is-active': isActive || inline,
             'is-mobile-modal': isMobileModal
-        }]"> 
+        }]">
         <div v-if="!inline"
             role="button"
             ref="trigger"
@@ -15,13 +15,13 @@
             <slot name="trigger"></slot>
         </div>
 
-        <transition name="fade">
+        <transition :name="transition">
             <div v-if="isMobileModal"
                 v-show="isActive"
                 class="background">
             </div>
         </transition>
-        <transition name="fade">
+        <transition :name="transition">
             <div v-show="isActive || hoverable || inline"
                 ref="dropdownMenu"
                 class="dropdown-menu">
@@ -53,6 +53,10 @@
                         'is-bottom-left'
                     ].indexOf(value) > -1
                 }
+            },
+            transition: {
+                type: String,
+                default: 'fade'
             },
             mobileModal: {
                 type: Boolean,


### PR DESCRIPTION
I'm have vue-cli@2.9.0 installed globally and I'm getting this error:
```
buefy$ yarn build:lib:js
yarn run v1.1.0
$ vue build src/index.js --prod --lib Buefy --dist lib

  We are slimming down vue-cli to optimize the initial installation by removing the `vue build` command.
  Check out Poi (https://github.com/egoist/poi) which offers the same functionality!
```

To fix this, I added vue-cli@2.8.0 as local dependency as "vue build" is removed in vue-cli@2.9.0 onwards.