### PR TITLE
Fix for "vue build" not working with vue-cli 2.9.0 onwards.

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "sw-precache-webpack-plugin": "^0.9.1",
     "url-loader": "^0.5.8",
     "vue-analytics": "^4.1.3",
+    "vue-cli": "2.8.0",
     "vue-loader": "^12.1.0",
     "vue-progressbar": "^0.7.2",
     "vue-router": "^2.3.1",


### PR DESCRIPTION
I'm have vue-cli@2.9.0 installed globally and I'm getting this error:
```
buefy$ yarn build:lib:js
yarn run v1.1.0
$ vue build src/index.js --prod --lib Buefy --dist lib

  We are slimming down vue-cli to optimize the initial installation by removing the `vue build` command.
  Check out Poi (https://github.com/egoist/poi) which offers the same functionality!
```

To fix this, I added vue-cli@2.8.0 as local dependency as "vue build" is removed in vue-cli@2.9.0 onwards.