### PR TITLE
 Feature: Adds "label-classes" prop to adjust label styling in b-field

### DIFF
--- a/docs/pages/components/field/Field.vue
+++ b/docs/pages/components/field/Field.vue
@@ -64,6 +64,14 @@
             <p>Add the <code>horizontal</code> prop for aligning label and control in horizontal forms.</p>
         </Example>
 
+        <Example :component="ExLabelClasses" :code="ExLabelClassesCode" title="Label classes">
+            <div class="tags has-addons">
+                <span class="tag is-success">New!</span>
+                <span class="tag is-info">0.6.3</span>
+            </div>
+            <p>Add the <code>label-classes</code> prop to adjust the styling of the label.</p>
+        </Example>
+
         <ApiView :data="api"/>
     </div>
 </template>
@@ -95,6 +103,9 @@
     import ExHorizontal from './examples/ExHorizontal'
     import ExHorizontalCode from '!!raw-loader!./examples/ExHorizontal'
 
+    import ExLabelClasses from './examples/ExLabelClasses'
+    import ExLabelClassesCode from '!!raw-loader!./examples/ExLabelClasses'
+
     export default {
         data() {
             return {
@@ -107,6 +118,7 @@
                 ExPositions,
                 ExCombineAddonsGroups,
                 ExHorizontal,
+                ExLabelClasses,
                 ExSimpleCode,
                 ExAddonsCode,
                 ExGroupsCode,
@@ -114,7 +126,8 @@
                 ExGroupMultilineCode,
                 ExPositionsCode,
                 ExCombineAddonsGroupsCode,
-                ExHorizontalCode
+                ExHorizontalCode,
+                ExLabelClassesCode
             }
         }
     }

--- a/docs/pages/components/field/api/field.js
+++ b/docs/pages/components/field/api/field.js
@@ -26,6 +26,13 @@ export default [
                 default: '—'
             },
             {
+                name: '<code>label-classes</code>',
+                description: 'CSS classes to be applied on field label',
+                type: 'String',
+                values: '—',
+                default: '—'
+            },
+            {
                 name: '<code>message</code>',
                 description: 'Help message text',
                 type: 'String, Array<String>',

--- a/docs/pages/components/field/examples/ExLabelClasses.vue
+++ b/docs/pages/components/field/examples/ExLabelClasses.vue
@@ -1,0 +1,51 @@
+<template>
+    <section>
+        <b-field label="Small" label-classes="is-small">
+            <b-input value="Kevin Garvey" size="is-small"></b-input>
+        </b-field>
+        <b-field label="Large" label-classes="is-large">
+            <b-input value="Kevin Garvey" size="is-large"></b-input>
+        </b-field>
+
+        <b-field label="Danger"
+            label-classes="has-text-danger"
+            type="is-danger"
+            message="This email is invalid">
+            <b-input type="email"
+                value="john@"
+                maxlength="30">
+            </b-input>
+        </b-field>
+
+        <b-field label="Multiple (small and success)"
+            label-classes="is-small has-text-success"
+            type="is-success"
+            >
+            <b-input value="johnsilver" maxlength="30" size="is-small"></b-input>
+        </b-field>
+
+        <b-field label="Computed (medium and primary)"
+            :label-classes="classes"
+            type="is-primary"
+            >
+            <b-input value="johnsilver" maxlength="30" size="is-medium"></b-input>
+        </b-field>
+
+    </section>
+</template>
+
+<script>
+    export default {
+        data() {
+            return {
+                firstClass: 'has-text-primary',
+                secondClass: 'is-medium'
+            }
+        },
+        computed: {
+            classes() {
+                return `${this.firstClass} ${this.secondClass}`
+            }
+        }
+    }
+</script>

--- a/src/components/field/Field.vue
+++ b/src/components/field/Field.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="field" :class="rootClasses">
-        <div v-if="horizontal" class="field-label is-normal">
+        <div
+            v-if="horizontal"
+            class="field-label is-normal"
+            :class="labelClasses">
             <label
                 v-if="label"
                 :for="labelFor"
@@ -12,7 +15,8 @@
             <label
                 v-if="label"
                 :for="labelFor"
-                class="label" >
+                class="label"
+                :class="labelClasses">
                 {{ label }}
             </label>
         </template>
@@ -52,7 +56,8 @@
             addons: {
                 type: Boolean,
                 default: true
-            }
+            },
+            labelClasses: String
         },
         data() {
             return {


### PR DESCRIPTION
With the "label-classes" prop one can adjust the label of a <b-field> to fit the styles of the controls inside it.

E.g. if the b-field contains an input with size "is-small", the label is not vertically centered unless "is-small" is added to it, too. Doing so is not possible at the moment, but easy with the changes of this PR