### PR TITLE
fix #491 add isAsc parameter to custom-sort function of b-table

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -401,7 +401,7 @@
                 let sorted = []
                 // Sorting without mutating original data
                 if (fn && typeof fn === 'function') {
-                    sorted = [...array].sort(fn)
+                    sorted = [...array].sort((a, b) => fn(a, b, isAsc))
                 } else {
                     sorted = [...array].sort((a, b) => {
                         // Get nested values from objects


### PR DESCRIPTION
This PR add an `isAsc` parameter to `custom-sort`. Fix issue described in #491.